### PR TITLE
node-icu-wordsplit update for Node 4+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,22 @@ GYP = node-gyp
 default: test
 
 clean:
-	$(GYP) clean
-	rm -Rf lib
+	@$(GYP) clean
+	@rm -Rf lib
 
 configure:
-	$(GYP) configure
+	@$(GYP) configure
 
 all: clean configure
-	$(GYP) build --verbose
-	mkdir -p lib
-	cp ./build/Release/wordsplit.node lib/
+	@$(GYP) build --verbose
+	@mkdir -p lib
+	@cp ./build/Release/wordsplit.node lib/
 
 test: all
-	node test/test.js
+	@node test/test.js
 
 leaktest: all
-	valgrind node test/leaktest.js
+	@valgrind node test/leaktest.js
 
 .PHONY: all test clean default leaktest
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,9 +5,13 @@
       "sources": ["src/wordsplit.cc"],
       "libraries": ["<!@(icu-config --ldflags)"],
       'include_dirs': [
-        '<!@(icu-config --cppflags-searchpath)',
         '<!(node -e "require(\'nan\')")'
       ],
+      'xcode_settings': {
+        'OTHER_CFLAGS': [
+          "<!(icu-config --cppflags)",
+        ],
+      },
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,11 +4,12 @@
       "target_name": "wordsplit",
       "sources": ["src/wordsplit.cc"],
       "libraries": ["<!@(icu-config --ldflags)"],
-      'include_dirs': [
+      "cflags": ["<!(icu-config --cppflags)"],
+      "include_dirs": [
         '<!(node -e "require(\'nan\')")'
       ],
-      'xcode_settings': {
-        'OTHER_CFLAGS': [
+      "xcode_settings": {
+        "OTHER_CFLAGS": [
           "<!(icu-config --cppflags)",
         ],
       },

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,12 +4,10 @@
       "target_name": "wordsplit",
       "sources": ["src/wordsplit.cc"],
       "libraries": ["<!@(icu-config --ldflags)"],
-      "cflags": ["<!@(icu-config --cppflags)"],
-      "conditions": [
-        ['OS=="mac"', {
-          "OTHER_CFLAGS": ["<!@(icu-config --cppflags)"]
-        }]
-      ]
+      'include_dirs': [
+        '<!@(icu-config --cppflags-searchpath)',
+        '<!(node -e "require(\'nan\')")'
+      ],
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "url": "git://github.com/chakrit/node-icu-wordsplit.git"
   },
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "nan": "^2.1.0"
+  },
   "optionalDependencies": {},
   "devDependencies": {
     "underscore": "latest",

--- a/src/wordsplit.cc
+++ b/src/wordsplit.cc
@@ -1,5 +1,4 @@
 #include <nan.h>
-#include <stdio.h>
 // ICU includes
 #include <unicode/brkiter.h>
 #include <unicode/errorcode.h>
@@ -17,8 +16,15 @@ using v8::String;
 // v8 shim
 // NOTE: arguments precondition checked in js wrapper file
 void SplitWords(const Nan::FunctionCallbackInfo<Value>& info) {
+  // Ignore the first parameter if we have 2 because ICU works great with en_US locale
   const char *cLocaleArg = "en_US";
-  Local<String> text = info[0]->ToString(Nan::GetCurrentContext()).ToLocalChecked();
+  int textIndex;
+  if (args.Length() == 2) {
+      textIndex = 1;
+  } else {
+      textIndex = 0;
+  }
+  Local<String> text = info[textIndex]->ToString(Nan::GetCurrentContext()).ToLocalChecked();
 
   uint16_t *cTextArg = new uint16_t[text->Length()+1];
   text->Write(cTextArg, 0, text->Length());
@@ -30,8 +36,6 @@ void SplitWords(const Nan::FunctionCallbackInfo<Value>& info) {
   }
 
   icu::UnicodeString uTextArg(cTextArg, text->Length());
-  printf("Text length: %d\n", text->Length());
-  fflush(stdout);
   if (uTextArg.isBogus()) {
     Nan::ThrowError("Failed to create UnicodeString");
     delete cTextArg;

--- a/src/wordsplit.cc
+++ b/src/wordsplit.cc
@@ -1,47 +1,42 @@
-
+#include <nan.h>
 #include <stdio.h>
-
-// node includes
-#include <v8.h>
-#include <node.h>
-
 // ICU includes
 #include <unicode/brkiter.h>
 #include <unicode/errorcode.h>
 #include <unicode/unistr.h>
 
+namespace wordsplit {
 
-// function template
-static v8::Persistent<v8::FunctionTemplate> ft_splitWords;
-static bool ft_splitWords_once = false;
-
-
-static v8::Handle<v8::Value>
-Throw(const char *message) {
-  return v8::ThrowException(v8::Exception::Error(v8::String::New(message)));
-}
-
+using v8::Value;
+using v8::Local;
+using v8::FunctionTemplate;
+using v8::Object;
+using v8::Array;
+using v8::String;
 
 // v8 shim
 // NOTE: arguments precondition checked in js wrapper file
-static v8::Handle<v8::Value>
-SplitWords(const v8::Arguments &args) {
-  v8::HandleScope scope;
+void SplitWords(const Nan::FunctionCallbackInfo<Value>& info) {
+  const char *cLocaleArg = "en_US";
+  Local<String> text = info[0]->ToString(Nan::GetCurrentContext()).ToLocalChecked();
 
-  // prepare ICU-compatible strings
-  v8::Local<v8::String> localeArg(args[0]->ToString());
-  v8::Local<v8::String> textArg(args[1]->ToString());
+  uint16_t *cTextArg = new uint16_t[text->Length()+1];
+  text->Write(cTextArg, 0, text->Length());
 
-  v8::String::AsciiValue localeArgValue(localeArg);
-  v8::String::Value textArgValue(textArg);
+  if (cTextArg == NULL) {
+    Nan::ThrowError("Error obtaining unicode string from v8::String");
+    delete cTextArg;
+    return;
+  }
 
-  const char *cLocaleArg = *localeArgValue;
-  const uint16_t *cTextArg = *textArgValue;
-
-  if (cTextArg == NULL) { return Throw("Error obtaining unicode string from v8::String."); }
-
-  UnicodeString uTextArg(cTextArg, textArg->Length());
-  if (uTextArg.isBogus()) { return Throw("Failed to create UnicodeString."); }
+  icu::UnicodeString uTextArg(cTextArg, text->Length());
+  printf("Text length: %d\n", text->Length());
+  fflush(stdout);
+  if (uTextArg.isBogus()) {
+    Nan::ThrowError("Failed to create UnicodeString");
+    delete cTextArg;
+    return;
+  }
 
   // prepare iterator
   UErrorCode err = U_ZERO_ERROR;
@@ -52,43 +47,37 @@ SplitWords(const v8::Arguments &args) {
     ErrorCode errCode;
     errCode.set(err);
 
-    return Throw(errCode.errorName());
+    Nan::ThrowError(errCode.errorName());
+    delete cTextArg;
+    return;
   }
 
   iter->setText(uTextArg);
 
   // iterate and store results
-  v8::Local<v8::Array> results = v8::Array::New();
+  Local<Array> results = Nan::New<Array>();
   int resultIdx = 0;
   int previousIdx = 0;
   int idx = -1;
 
   while ((idx = iter->next()) != -1) {
     const uint16_t *wordStart = cTextArg + previousIdx;
-    v8::Local<v8::String> word;
 
-    results->Set(resultIdx++, v8::String::New(wordStart, idx - previousIdx));
+    Nan::Set(results, resultIdx++, Nan::New<String>(wordStart, idx - previousIdx).ToLocalChecked());
     previousIdx = idx;
   }
 
   // finish
   delete iter;
-  return scope.Close(results);
+  delete cTextArg;
+  info.GetReturnValue().Set(results);
 }
 
-
-// module setup
-static void
-Init(v8::Handle<v8::Object> exports) {
-  v8::HandleScope scope;
-
-  if (!ft_splitWords_once) {
-    ft_splitWords = v8::Persistent<v8::FunctionTemplate>::New(v8::FunctionTemplate::New(SplitWords));
-    ft_splitWords_once = true;
-  }
-
-  exports->Set(v8::String::NewSymbol("splitWords"), ft_splitWords->GetFunction());
+void Init(Local<Object> exports) {
+    exports->Set(Nan::New("splitWords").ToLocalChecked(),
+            Nan::New<FunctionTemplate>(SplitWords)->GetFunction());
 }
 
-NODE_MODULE(wordsplit, Init);
+NODE_MODULE(addon, Init)
 
+}

--- a/src/wordsplit.cc
+++ b/src/wordsplit.cc
@@ -19,7 +19,7 @@ void SplitWords(const Nan::FunctionCallbackInfo<Value>& info) {
   // Ignore the first parameter if we have 2 because ICU works great with en_US locale
   const char *cLocaleArg = "en_US";
   int textIndex;
-  if (args.Length() == 2) {
+  if (info.Length() == 2) {
       textIndex = 1;
   } else {
       textIndex = 0;


### PR DESCRIPTION
node-icu-wordsplit doesn't compile anymore on Node 4+. This diff updates the repo, includes `nan` as a dependency and make it compile again on newer versions of Node. It also fixes the compilation problems on Mac OS X which needs special attention to allow compiling using xcode tools.
